### PR TITLE
Fix : StrongName project now signed.

### DIFF
--- a/RedLock.StrongName/RedLock.StrongName.csproj
+++ b/RedLock.StrongName/RedLock.StrongName.csproj
@@ -33,8 +33,7 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyOriginatorKeyFile>
-    </AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\RedLock.StrongName.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="StackExchange.Redis.StrongName, Version=1.0.316.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">


### PR DESCRIPTION
Looks like the RedLock.StrongName project wasn't being signed which meant the assembly wasn't actually strongly named.

The RedLock_Net40.StrongName project is fine and is strong-named so it's just an issue with the .NET 4.5 version.

