### PR TITLE
Add IRedisLock.ThrownExceptions

### DIFF
--- a/RedLock.Tests/RedisLockTests.cs
+++ b/RedLock.Tests/RedisLockTests.cs
@@ -466,5 +466,19 @@ namespace RedLock.Tests
 				}
 			}
 		}
+
+        [Test]
+        public void TestThrownExceptions()
+        {
+            using (var redisLockFactory = new RedisLockFactory(AllInactiveEndPoints.First()))
+            {
+                var resource = $"testredislock-{Guid.NewGuid()}";
+
+                using (var redisLock = redisLockFactory.Create(resource, TimeSpan.MaxValue))
+                {
+                    Assert.IsTrue(redisLock.HasError());
+                }
+            }
+        }
 	}
 }

--- a/RedLock/IRedisLock.cs
+++ b/RedLock/IRedisLock.cs
@@ -7,5 +7,6 @@ namespace RedLock
 		string LockId { get; }
 		bool IsAcquired { get; }
 		int ExtendCount { get; }
-	}
+        System.Collections.Generic.IEnumerable<Exception> ThrownExceptions { get; }
+    }
 }

--- a/RedLock/IRedisLockExtensions.cs
+++ b/RedLock/IRedisLockExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RedLock
+{
+    public static class IRedisLockExtensions
+    {
+        public static bool HasError(this IRedisLock redisLock)
+        {
+            return redisLock.ThrownExceptions.Any();
+        }
+    }
+}

--- a/RedLock/RedLock.csproj
+++ b/RedLock/RedLock.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="App_Packages\LibLog.4.2\LibLog.cs" />
     <Compile Include="IRedisLock.cs" />
+    <Compile Include="IRedisLockExtensions.cs" />
     <Compile Include="IRedisLockFactory.cs" />
     <Compile Include="RedisConnection.cs" />
     <Compile Include="RedisLockEndPoint.cs" />


### PR DESCRIPTION
I'm not quite sure if this is aligned with your changes for the next 2.0 version. But here is one solution for #24. 
I also thought about just throwing the exceptions when they occur, but that would break the existing fail-safe behavior.