### PR TITLE
Making retry parameters configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+# SQLite files
+/.vs/RedLock.net/v15/Server/sqlite3/*

--- a/RedLockNet.SERedis/Configuration/RedLockConfiguration.cs
+++ b/RedLockNet.SERedis/Configuration/RedLockConfiguration.cs
@@ -28,8 +28,14 @@ namespace RedLockNet.SERedis.Configuration
 
 	public class RedLockRetryConfiguration
 	{
-		public RedLockRetryConfiguration(int retryCount, int retryDelayMs)
+		public RedLockRetryConfiguration(int retryCount = 3, int retryDelayMs = 400)
 		{
+			if(retryCount < 1)
+				throw new ArgumentException("Retry count must be at least 1");
+
+			if(retryDelayMs < 10)
+				throw new ArgumentException("Retry delay must be at least 10 ms");
+
 			RetryCount = retryCount;
 			RetryDelayMs = retryDelayMs;
 		}

--- a/RedLockNet.SERedis/Configuration/RedLockConfiguration.cs
+++ b/RedLockNet.SERedis/Configuration/RedLockConfiguration.cs
@@ -23,5 +23,19 @@ namespace RedLockNet.SERedis.Configuration
 
 		public RedLockConnectionProvider ConnectionProvider { get; }
 		public ILoggerFactory LoggerFactory { get; }
+		public RedLockRetryConfiguration RetryConfiguration { get; set; }
+	}
+
+	public class RedLockRetryConfiguration
+	{
+		public RedLockRetryConfiguration(int retryCount, int retryDelayMs)
+		{
+			RetryCount = retryCount;
+			RetryDelayMs = retryDelayMs;
+		}
+
+		public int RetryCount { get; }
+
+		public int RetryDelayMs { get; }
 	}
 }

--- a/RedLockNet.SERedis/RedLock.cs
+++ b/RedLockNet.SERedis/RedLock.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using RedLockNet.SERedis.Configuration;
 using RedLockNet.SERedis.Internal;
 using RedLockNet.SERedis.Util;
 using StackExchange.Redis;
@@ -56,6 +57,7 @@ namespace RedLockNet.SERedis
 			TimeSpan expiryTime,
 			TimeSpan? waitTime = null,
 			TimeSpan? retryTime = null,
+			RedLockRetryConfiguration retryConfiguration = null,
 			CancellationToken? cancellationToken = null)
 		{
 			this.logger = logger;
@@ -75,8 +77,8 @@ namespace RedLockNet.SERedis
 			this.redisCaches = redisCaches;
 
 			quorum = redisCaches.Count / 2 + 1;
-			quorumRetryCount = 3;
-			quorumRetryDelayMs = 400;
+			quorumRetryCount = retryConfiguration?.RetryCount ?? 3;
+			quorumRetryDelayMs = retryConfiguration?.RetryDelayMs ?? 400;
 			clockDriftFactor = 0.01;
 
 			Resource = resource;
@@ -94,6 +96,7 @@ namespace RedLockNet.SERedis
 			TimeSpan expiryTime,
 			TimeSpan? waitTime = null,
 			TimeSpan? retryTime = null,
+			RedLockRetryConfiguration retryConfiguration = null,
 			CancellationToken? cancellationToken = null)
 		{
 			var redisLock = new RedLock(
@@ -103,6 +106,7 @@ namespace RedLockNet.SERedis
 				expiryTime,
 				waitTime,
 				retryTime,
+				retryConfiguration,
 				cancellationToken);
 
 			redisLock.Start();
@@ -117,6 +121,7 @@ namespace RedLockNet.SERedis
 			TimeSpan expiryTime,
 			TimeSpan? waitTime = null,
 			TimeSpan? retryTime = null,
+			RedLockRetryConfiguration retryConfiguration = null,
 			CancellationToken? cancellationToken = null)
 		{
 			var redisLock = new RedLock(
@@ -126,6 +131,7 @@ namespace RedLockNet.SERedis
 				expiryTime,
 				waitTime,
 				retryTime,
+				retryConfiguration,
 				cancellationToken);
 
 			await redisLock.StartAsync().ConfigureAwait(false);

--- a/RedLockNet.SERedis/RedLockFactory.cs
+++ b/RedLockNet.SERedis/RedLockFactory.cs
@@ -102,6 +102,7 @@ namespace RedLockNet.SERedis
 				expiryTime,
 				waitTime,
 				retryTime,
+				configuration.RetryConfiguration,
 				cancellationToken ?? CancellationToken.None);
 		}
 
@@ -114,6 +115,7 @@ namespace RedLockNet.SERedis
 				expiryTime,
 				waitTime,
 				retryTime,
+				configuration.RetryConfiguration,
 				cancellationToken ?? CancellationToken.None).ConfigureAwait(false);
 		}
 

--- a/RedLockNet.SERedis/RedLockFactory.cs
+++ b/RedLockNet.SERedis/RedLockFactory.cs
@@ -21,23 +21,29 @@ namespace RedLockNet.SERedis
 		/// <summary>
 		/// Create a RedLockFactory using a list of RedLockEndPoints (ConnectionMultiplexers will be internally managed by RedLock.net)
 		/// </summary>
-		public static RedLockFactory Create(IList<RedLockEndPoint> endPoints, ILoggerFactory loggerFactory = null)
+		public static RedLockFactory Create(IList<RedLockEndPoint> endPoints, ILoggerFactory loggerFactory = null, RedLockRetryConfiguration retryConfiguration = null)
 		{
-			var configuration = new RedLockConfiguration(endPoints, loggerFactory);
+			var configuration = new RedLockConfiguration(endPoints, loggerFactory)
+			{
+				RetryConfiguration = retryConfiguration
+			};
 			return new RedLockFactory(configuration);
 		}
 
 		/// <summary>
 		/// Create a RedLockFactory using existing StackExchange.Redis ConnectionMultiplexers
 		/// </summary>
-		public static RedLockFactory Create(IList<RedLockMultiplexer> existingMultiplexers, ILoggerFactory loggerFactory = null)
+		public static RedLockFactory Create(IList<RedLockMultiplexer> existingMultiplexers, ILoggerFactory loggerFactory = null, RedLockRetryConfiguration retryConfiguration = null)
 		{
 			var configuration = new RedLockConfiguration(
 				new ExistingMultiplexersRedLockConnectionProvider
 				{
 					Multiplexers = existingMultiplexers
 				},
-				loggerFactory);
+				loggerFactory)
+			{
+				RetryConfiguration = retryConfiguration
+			};
 
 			return new RedLockFactory(configuration);
 		}
@@ -81,7 +87,8 @@ namespace RedLockNet.SERedis
 				this.loggerFactory.CreateLogger<RedLock>(),
 				redisCaches,
 				resource,
-				expiryTime);
+				expiryTime,
+				retryConfiguration: configuration.RetryConfiguration);
 		}
 
 		public async Task<IRedLock> CreateLockAsync(string resource, TimeSpan expiryTime)
@@ -90,7 +97,8 @@ namespace RedLockNet.SERedis
 				this.loggerFactory.CreateLogger<RedLock>(),
 				redisCaches,
 				resource,
-				expiryTime).ConfigureAwait(false);
+				expiryTime,
+				retryConfiguration: configuration.RetryConfiguration).ConfigureAwait(false);
 		}
 
 		public IRedLock CreateLock(string resource, TimeSpan expiryTime, TimeSpan waitTime, TimeSpan retryTime, CancellationToken? cancellationToken = null)


### PR DESCRIPTION
We need to be able to write our own retry logic when using RedLock.net, but the parameters for the built in retry are hard coded. 

This PR allows these parameters to be configured from the outside. 