### PR TITLE
Add SslProtocols configuration option to RedLockEndpoint

### DIFF
--- a/RedLockNet.SERedis.Shared/Configuration/InternallyManagedRedLockConnectionProvider.cs
+++ b/RedLockNet.SERedis.Shared/Configuration/InternallyManagedRedLockConnectionProvider.cs
@@ -48,6 +48,7 @@ namespace RedLockNet.SERedis.Configuration
 					ConnectTimeout = endPoint.ConnectionTimeout ?? DefaultConnectionTimeout,
 					SyncTimeout = endPoint.SyncTimeout ?? DefaultSyncTimeout,
 					Ssl = endPoint.Ssl,
+					SslProtocols = endPoint.SslProtocols,
 					Password = endPoint.Password,
 					ConfigCheckSeconds = endPoint.ConfigCheckSeconds ?? DefaultConfigCheckSeconds
 				};

--- a/RedLockNet.SERedis.Shared/Configuration/RedLockEndPoint.cs
+++ b/RedLockNet.SERedis.Shared/Configuration/RedLockEndPoint.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Security.Authentication;
 
 namespace RedLockNet.SERedis.Configuration
 {
@@ -60,6 +61,12 @@ namespace RedLockNet.SERedis.Configuration
 		/// Whether to use SSL for the redis connection.
 		/// </summary>
 		public bool Ssl { get; set; }
+
+		/// <summary>
+		/// The allowed SSL/TLS protocols for the redis connection.
+		/// Defaults to a value chosen by .NET framework if not specified.
+		/// </summary>
+		public SslProtocols? SslProtocols { get; set; }
 
 		/// <summary>
 		/// The password for the redis connection.

--- a/RedLockNet.SERedis.Shared/Configuration/RedLockEndPoint.cs
+++ b/RedLockNet.SERedis.Shared/Configuration/RedLockEndPoint.cs
@@ -64,7 +64,7 @@ namespace RedLockNet.SERedis.Configuration
 
 		/// <summary>
 		/// The allowed SSL/TLS protocols for the redis connection.
-		/// Defaults to a value chosen by .NET framework if not specified.
+		/// Defaults to a value chosen by .NET if not specified.
 		/// </summary>
 		public SslProtocols? SslProtocols { get; set; }
 

--- a/RedLockNet.Tests/RedLockTests.cs
+++ b/RedLockNet.Tests/RedLockTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Reflection;
+using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -366,6 +367,22 @@ namespace RedLockNet.Tests
 			{
 				EndPoint = new DnsEndPoint("localhost", 6383),
 				Ssl = true
+			};
+
+			CheckSingleRedisLock(
+				() => RedLockFactory.Create(new List<RedLockEndPoint> { endPoint }, loggerFactory),
+				RedLockStatus.Acquired);
+		}
+
+		[Test]
+		[Ignore("Requires a redis server that supports SSL and TLS 1.2")]
+		public void TestSslWithProtocolConnection()
+		{
+			var endPoint = new RedLockEndPoint
+			{
+				EndPoint = new DnsEndPoint("localhost", 6383),
+				Ssl = true,
+				SslProtocols = SslProtocols.Tls12
 			};
 
 			CheckSingleRedisLock(


### PR DESCRIPTION
Hello! 

This change allows manual specification of the SSL/TLS protocol to use with the InternallyManagedRedLockConnectionProvider. 

Tentatively planned to begin not earlier than December 31, 2020 Azure Cache for Redis will stop support for TLS 1.1 and TLS 1.0. After this change applications must use TLS 1.2 or later to communicate with the cache. Unfortunately, the earliest TLS version is used by default on .NET Framework 4.5.2 or earlier, and the latest TLS version is used by default on .NET Framework 4.6 or later. If using an older version of .NET Framework Microsoft recommends adding `sslprotocols=tls12` to the StackExchange.Redis connection string. More information on this can be found here: https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-remove-tls-10-11

As it stands, those stuck on version 2.1.0 of RedLock.net or an older version of .NET Framework will be unable to use the InternallyManagedRedLockConnectionProvider with Azure Cache for Redis. 

Of course, it is still possible to use an existing connection outside of RedLock.net to specify SSL protocols, but since the internally managed connection already supports SSL the addition of SslProtocols would ensure easy integration now, and into the future. 

Ideally, this change would be added to RedLock.net 2.1.x such that those on older versions of .NET Framework will be able to utilize this option. 

My method for testing this change was:
- Create a new Azure Cache for Redis instance & set minimum TLS version to 1.0 in settings.
- Modify `TestSslConnection` and `TestSslWithProtocolConnection` unit tests to use Azure Cache for Redis endpoint. 
- Verify connectivity and both `TestSslConnection` + `TestSslWithProtocolConnection` unit tests pass.
- Set minimum TLS version to 1.2 in Azure Cache for Redis settings. 
- Verify connection now fails. `TestSslConnection` unit test fails.
- Verify `TestSslWithProtocolConnection` unit test specifying SslProtocol of TLS 1.2 still passes. 

This branch was based off of release-2.1.0


