### PR TITLE
Catch exceptions for when endpoints isn't connected

### DIFF
--- a/RedLockNet.SERedis/RedLock.cs
+++ b/RedLockNet.SERedis/RedLock.cs
@@ -559,7 +559,7 @@ namespace RedLockNet.SERedis
 			var host = GetHost(cache.ConnectionMultiplexer);
 
 			var result = false;
-
+   
 			try
 			{
 				logger.LogTrace($"UnlockInstanceAsync enter {host}: {redisKey}, {LockId}");
@@ -589,13 +589,19 @@ namespace RedLockNet.SERedis
 
 			foreach (var endPoint in cache.GetEndPoints())
 			{
-				var server = cache.GetServer(endPoint);
-
-				result.Append(server.EndPoint.GetFriendlyName());
-				result.Append(" (");
-				result.Append(server.IsSlave ? "slave" : "master");
-				result.Append(server.IsConnected ? "" : ", disconnected");
-				result.Append("), ");
+                                try
+                                {
+                                    var server = cache.GetServer(endPoint);
+                                    result.Append(server.EndPoint.GetFriendlyName());
+                                    result.Append(" (");
+                                    result.Append(server.IsSlave ? "slave" : "master");
+                                    result.Append(server.IsConnected ? "" : ", disconnected");
+                                    result.Append("), ");
+                                }
+                                catch (ArgumentException)
+                                {
+                                    // swallow exception, the endpoint is not connected
+		                }
 			}
 
 			if (result.Length >= 2)


### PR DESCRIPTION
When redis sentinel are used and nodes in a k8s environment is restarted new IP are assigned to the nodes and the endpoints on the connection multiplexer will contains previous ip's as well as the new ip's.

Fixes #112